### PR TITLE
add test dependency six

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 requests
 Django>=2.0
 djangorestframework>=3.8.2
+six

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,3 @@
 pytest
 pytest-django
 pytest-cov
-six

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@
 pytest
 pytest-django
 pytest-cov
+six


### PR DESCRIPTION
When running `make test` I got errors that the module `six` is not available.
Adding it to the test dependencies solved the issue for me.