### PR TITLE
Include 'username' in UserSerializer only if included in USER_FIELDS

### DIFF
--- a/drf_registration/api/user.py
+++ b/drf_registration/api/user.py
@@ -16,10 +16,12 @@ class UserSerializer(serializers.ModelSerializer):
     email = serializers.EmailField(
         validators=[UniqueValidator(queryset=get_all_users(),
                                     message=_('User with this email already exists.'))])
-    username = serializers.CharField(validators=[UniqueValidator(
-        queryset=get_all_users(),
-        message=_('User with this username already exists.')
-    )])
+
+    if 'username' in drfr_settings.USER_FIELDS:
+        username = serializers.CharField(validators=[UniqueValidator(
+            queryset=get_all_users(),
+            message=_('User with this username already exists.')
+        )])
 
     if enable_has_password():
         has_password = serializers.SerializerMethodField()

--- a/drf_registration/api/user.py
+++ b/drf_registration/api/user.py
@@ -13,9 +13,10 @@ class UserSerializer(serializers.ModelSerializer):
     User serializer
     """
 
-    email = serializers.EmailField(
-        validators=[UniqueValidator(queryset=get_all_users(),
-                                    message=_('User with this email already exists.'))])
+    if 'email' in drfr_settings.USER_FIELDS:
+        email = serializers.EmailField(
+            validators=[UniqueValidator(queryset=get_all_users(),
+                                        message=_('User with this email already exists.'))])
 
     if 'username' in drfr_settings.USER_FIELDS:
         username = serializers.CharField(validators=[UniqueValidator(


### PR DESCRIPTION
My app uses email for authentication instead of username. The User model has no username field. I had to redefine the entire UserSerializer class just to remove the username field from the serializer to avoid an exception.